### PR TITLE
feat(patients): patient management workflow (add, link, documents)

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -50,6 +50,11 @@ const routes: Routes = [
     canActivate: [AuthGuard],
   },
   {
+    path: 'patients',
+    loadChildren: () => import('./views/patients/patients.module').then((m) => m.PatientsPageModule),
+    canActivate: [AuthGuard],
+  },
+  {
     path: 'recovery-password',
     loadChildren: () => import('./views/recovery-password/recovery-password.module').then( m => m.RecoveryPasswordModule)
   },

--- a/src/app/views/patients/add-patient/add-patient.page.scss
+++ b/src/app/views/patients/add-patient/add-patient.page.scss
@@ -1,0 +1,21 @@
+:host {
+  .ap {
+    &__search {
+      padding: 16px;
+      &__label {
+        font-weight: 600;
+        margin-bottom: 12px;
+        display: block;
+      }
+    }
+    &__result {
+      padding: 0 16px;
+    }
+    &__not-found {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      padding: 32px 16px;
+    }
+  }
+}

--- a/src/app/views/patients/add-patient/add-patient.page.ts
+++ b/src/app/views/patients/add-patient/add-patient.page.ts
@@ -1,0 +1,124 @@
+import { Component, OnInit } from '@angular/core';
+import { FormBuilder, Validators } from '@angular/forms';
+import { NavController } from '@ionic/angular';
+import { AuthenticationService } from 'src/app/services/authentication/authentication.service';
+import { ToastService } from 'src/app/services/toast/toast.service';
+import { PatientsService } from '../shared/services/patients.service';
+
+@Component({
+  selector: 'app-add-patient',
+  template: `
+    <ion-header class="ui-background__light">
+      <ion-toolbar class="ui-toolbar__primary">
+        <ion-buttons slot="start">
+          <ion-back-button defaultHref="/patients"></ion-back-button>
+        </ion-buttons>
+        <ion-title class="ui-header__title-center">Agregar Paciente</ion-title>
+      </ion-toolbar>
+    </ion-header>
+    <ion-content class="ap">
+      <div class="ap__search">
+        <ion-label class="ap__search__label">Ingrese el DNI del paciente</ion-label>
+        <form [formGroup]="searchForm" (ngSubmit)="searchPatient()">
+          <ion-item>
+            <ion-input
+              formControlName="dni"
+              placeholder="DNI"
+              type="number"
+              inputmode="numeric"
+            ></ion-input>
+          </ion-item>
+          <ion-button
+            expand="block"
+            type="submit"
+            [disabled]="searchForm.invalid || isSearching"
+            style="margin-top: 16px;"
+          >
+            {{ isSearching ? 'Buscando...' : 'Buscar' }}
+          </ion-button>
+        </form>
+      </div>
+
+      <div class="ap__result" *ngIf="foundPatient">
+        <ion-card>
+          <ion-card-header>
+            <ion-card-title>{{ foundPatient.firstName }} {{ foundPatient.lastName }}</ion-card-title>
+            <ion-card-subtitle>DNI: {{ foundPatient.dni }}</ion-card-subtitle>
+          </ion-card-header>
+          <ion-card-content>
+            <ion-button
+              expand="block"
+              (click)="linkPatient()"
+              [disabled]="isLinking"
+            >
+              {{ isLinking ? 'Vinculando...' : 'Vincular como paciente' }}
+            </ion-button>
+          </ion-card-content>
+        </ion-card>
+      </div>
+
+      <div class="ap__not-found" *ngIf="searchDone && !foundPatient">
+        <ion-icon name="alert-circle-outline" style="font-size: 48px; color: var(--ion-color-warning);"></ion-icon>
+        <ion-label style="text-align: center; margin-top: 12px;">
+          No se encontró un usuario con ese DNI.
+        </ion-label>
+      </div>
+    </ion-content>
+  `,
+  styleUrls: ['./add-patient.page.scss'],
+})
+export class AddPatientPage implements OnInit {
+  searchForm = this.fb.group({
+    dni: ['', [Validators.required]],
+  });
+
+  foundPatient: any = null;
+  searchDone = false;
+  isSearching = false;
+  isLinking = false;
+
+  constructor(
+    private fb: FormBuilder,
+    private navController: NavController,
+    private authService: AuthenticationService,
+    private patientsService: PatientsService,
+    private toastService: ToastService,
+  ) {}
+
+  ngOnInit() {}
+
+  async searchPatient() {
+    const dni = this.searchForm.get('dni').value;
+    this.isSearching = true;
+    this.foundPatient = null;
+    this.searchDone = false;
+    try {
+      const user = await this.authService.getUserByDni(dni);
+      if (user && user.firstName) {
+        this.foundPatient = { ...user, patientType: 'user' };
+      }
+    } catch {
+      // Not found
+    }
+    this.searchDone = true;
+    this.isSearching = false;
+  }
+
+  async linkPatient() {
+    if (!this.foundPatient) return;
+    this.isLinking = true;
+    try {
+      await this.patientsService.linkPatient(
+        this.foundPatient.id,
+        this.foundPatient.patientType,
+      );
+      this.toastService.showSuccess('Paciente vinculado correctamente');
+      this.navController.back();
+    } catch (error) {
+      const message = error?.error?.message || 'Error al vincular paciente';
+      this.toastService.showError(message);
+    } finally {
+      this.isLinking = false;
+    }
+  }
+}

--- a/src/app/views/patients/patient-documents/patient-documents.page.scss
+++ b/src/app/views/patients/patient-documents/patient-documents.page.scss
@@ -1,0 +1,11 @@
+:host {
+  .pd {
+    &__empty {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      height: 60%;
+    }
+  }
+}

--- a/src/app/views/patients/patient-documents/patient-documents.page.ts
+++ b/src/app/views/patients/patient-documents/patient-documents.page.ts
@@ -1,0 +1,84 @@
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { NavController } from '@ionic/angular';
+import { ToastService } from 'src/app/services/toast/toast.service';
+import { MedicalDocument } from 'src/app/views/documents/shared/interfaces/Document.interface';
+import { PatientsService } from '../shared/services/patients.service';
+
+@Component({
+  selector: 'app-patient-documents',
+  template: `
+    <ion-header class="ui-background__light">
+      <ion-toolbar class="ui-toolbar__primary">
+        <ion-buttons slot="start">
+          <ion-back-button defaultHref="/patients"></ion-back-button>
+        </ion-buttons>
+        <ion-title class="ui-header__title-center">{{ patientName }}</ion-title>
+      </ion-toolbar>
+    </ion-header>
+    <ion-content class="pd">
+      <ion-label class="view-title" style="padding: 16px;">Documentos del paciente</ion-label>
+      <ion-list *ngIf="documents.length > 0">
+        <app-document-item-list
+          *ngFor="let doc of documents"
+          [document]="doc"
+          [flush]="true"
+          (click)="viewDocument(doc.id)"
+        ></app-document-item-list>
+      </ion-list>
+      <div class="pd__empty" *ngIf="documents.length === 0 && !isLoading">
+        <ion-icon name="document-text-outline" style="font-size: 64px; color: var(--ion-color-medium);"></ion-icon>
+        <ion-label style="text-align: center; margin-top: 16px; color: var(--ion-color-medium);">
+          Este paciente no tiene documentos cargados.
+        </ion-label>
+      </div>
+      <ion-spinner *ngIf="isLoading" name="crescent" style="display: block; margin: 32px auto;"></ion-spinner>
+    </ion-content>
+  `,
+  styleUrls: ['./patient-documents.page.scss'],
+})
+export class PatientDocumentsPage implements OnInit {
+  patientId: number;
+  patientType: string;
+  patientName = 'Documentos';
+  documents: MedicalDocument[] = [];
+  isLoading = false;
+
+  constructor(
+    private route: ActivatedRoute,
+    private navController: NavController,
+    private patientsService: PatientsService,
+    private toastService: ToastService,
+  ) {}
+
+  ngOnInit() {}
+
+  async ionViewWillEnter() {
+    this.patientId = Number(this.route.snapshot.paramMap.get('patientId'));
+    this.route.queryParams.subscribe((params) => {
+      this.patientType = params['patientType'] || 'user';
+      this.patientName = params['name'] || 'Documentos';
+    });
+    await this.loadDocuments();
+  }
+
+  private async loadDocuments() {
+    this.isLoading = true;
+    try {
+      this.documents =
+        (await this.patientsService.getPatientDocuments(
+          this.patientId,
+          this.patientType,
+        )) || [];
+    } catch (error) {
+      this.toastService.showError('Error al cargar documentos del paciente');
+      this.documents = [];
+    } finally {
+      this.isLoading = false;
+    }
+  }
+
+  viewDocument(id: number) {
+    this.navController.navigateForward([`/documents/view/${id}`]);
+  }
+}

--- a/src/app/views/patients/patients.module.ts
+++ b/src/app/views/patients/patients.module.ts
@@ -1,0 +1,44 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { IonicModule } from '@ionic/angular';
+import { RouterModule, Routes } from '@angular/router';
+import { HTTP_INTERCEPTORS } from '@angular/common/http';
+import { TokenInterceptor } from 'src/app/services/interceptors/token-interceptor.service';
+import { SharedComponentsModule } from 'src/app/components/shared-components.module';
+import { SharedDocumentsModule } from '../documents/shared/shared-documents.module';
+import { PatientsPage } from './patients.page';
+import { AddPatientPage } from './add-patient/add-patient.page';
+import { PatientDocumentsPage } from './patient-documents/patient-documents.page';
+
+const routes: Routes = [
+  {
+    path: '',
+    component: PatientsPage,
+  },
+  {
+    path: 'add',
+    component: AddPatientPage,
+  },
+  {
+    path: ':patientId/documents',
+    component: PatientDocumentsPage,
+  },
+];
+
+@NgModule({
+  imports: [
+    RouterModule.forChild(routes),
+    CommonModule,
+    FormsModule,
+    ReactiveFormsModule,
+    IonicModule,
+    SharedComponentsModule,
+    SharedDocumentsModule,
+  ],
+  declarations: [PatientsPage, AddPatientPage, PatientDocumentsPage],
+  providers: [
+    { provide: HTTP_INTERCEPTORS, useClass: TokenInterceptor, multi: true },
+  ],
+})
+export class PatientsPageModule {}

--- a/src/app/views/patients/patients.page.scss
+++ b/src/app/views/patients/patients.page.scss
@@ -1,0 +1,20 @@
+:host {
+  .pts {
+    &__form {
+      padding: 0 16px;
+    }
+    &__list {
+      padding: 0;
+    }
+    &__empty {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      height: 60%;
+    }
+    &__fab {
+      --background: var(--ion-color-primary);
+    }
+  }
+}

--- a/src/app/views/patients/patients.page.ts
+++ b/src/app/views/patients/patients.page.ts
@@ -1,0 +1,133 @@
+import { Component, OnInit } from '@angular/core';
+import { FormBuilder } from '@angular/forms';
+import { NavController, ModalController } from '@ionic/angular';
+import { YesNoModalComponent } from 'src/app/components/yes-no-modal/yes-no-modal.component';
+import { ToastService } from 'src/app/services/toast/toast.service';
+import { PatientLink } from './shared/interfaces/PatientLink.interface';
+import { PatientsService } from './shared/services/patients.service';
+
+@Component({
+  selector: 'app-patients',
+  template: `
+    <ion-header class="ui-background__light">
+      <ion-toolbar class="ui-toolbar__primary">
+        <ion-buttons slot="start">
+          <ion-back-button defaultHref="/profile"></ion-back-button>
+        </ion-buttons>
+        <ion-title class="ui-header__title-center">Mis Pacientes</ion-title>
+      </ion-toolbar>
+    </ion-header>
+    <ion-content class="pts">
+      <form class="pts__form" [formGroup]="searchForm">
+        <ion-searchbar
+          formControlName="search"
+          placeholder="Buscar pacientes ..."
+          class="ui-search-input ui-search-input__no-show"
+          debounce="400"
+          type="string"
+          (ionChange)="handleChange($event)"
+        ></ion-searchbar>
+      </form>
+      <ion-list class="pts__list" *ngIf="filteredPatients.length > 0">
+        <app-items-list
+          *ngFor="let patient of filteredPatients"
+          [title]="patient.firstName + ' ' + patient.lastName"
+          [subtitle]="patient.patientType === 'dependent' ? 'Dependiente' : 'Usuario'"
+          img="doctor"
+          [showIcon]="true"
+          (click)="viewDocuments(patient)"
+          (press)="confirmUnlink(patient)"
+        ></app-items-list>
+      </ion-list>
+      <div class="pts__empty" *ngIf="filteredPatients.length === 0 && !isLoading">
+        <ion-icon name="people-outline" style="font-size: 64px; color: var(--ion-color-medium);"></ion-icon>
+        <ion-label style="text-align: center; margin-top: 16px; color: var(--ion-color-medium);">
+          No tenés pacientes vinculados.<br />
+          Presioná + para agregar uno.
+        </ion-label>
+      </div>
+      <ion-fab vertical="bottom" horizontal="center" slot="fixed">
+        <ion-fab-button (click)="addPatient()" class="pts__fab">
+          <ion-icon name="add"></ion-icon>
+        </ion-fab-button>
+      </ion-fab>
+    </ion-content>
+  `,
+  styleUrls: ['./patients.page.scss'],
+})
+export class PatientsPage implements OnInit {
+  searchForm = this.fb.group({ search: '' });
+  patients: PatientLink[] = [];
+  filteredPatients: PatientLink[] = [];
+  isLoading = false;
+
+  constructor(
+    private fb: FormBuilder,
+    private navController: NavController,
+    private patientsService: PatientsService,
+    private modalController: ModalController,
+    private toastService: ToastService,
+  ) {}
+
+  ngOnInit() {}
+
+  async ionViewWillEnter() {
+    await this.loadPatients();
+  }
+
+  private async loadPatients() {
+    this.isLoading = true;
+    try {
+      this.patients = (await this.patientsService.getPatients()) || [];
+      this.filteredPatients = this.patients;
+    } catch (error) {
+      this.toastService.showError('Error al cargar pacientes');
+      this.patients = [];
+      this.filteredPatients = [];
+    } finally {
+      this.isLoading = false;
+    }
+  }
+
+  handleChange(event) {
+    const search = (event.detail.value || '').toLowerCase();
+    this.filteredPatients = this.patients.filter(
+      (p) =>
+        p.firstName.toLowerCase().includes(search) ||
+        p.lastName.toLowerCase().includes(search),
+    );
+  }
+
+  addPatient() {
+    this.navController.navigateForward(['/patients/add']);
+  }
+
+  viewDocuments(patient: PatientLink) {
+    this.navController.navigateForward([
+      `/patients/${patient.patientId}/documents`,
+    ], {
+      queryParams: { patientType: patient.patientType, name: `${patient.firstName} ${patient.lastName}` },
+    });
+  }
+
+  async confirmUnlink(patient: PatientLink) {
+    const modal = await this.modalController.create({
+      component: YesNoModalComponent,
+      cssClass: 'modal',
+      componentProps: {
+        text: `¿Desvincular a ${patient.firstName} ${patient.lastName}?`,
+      },
+    });
+    await modal.present();
+    const { data } = await modal.onWillDismiss();
+    if (data) {
+      try {
+        await this.patientsService.unlinkPatient(patient.patientId, patient.patientType);
+        this.toastService.showSuccess('Paciente desvinculado');
+        await this.loadPatients();
+      } catch {
+        this.toastService.showError('Error al desvincular');
+      }
+    }
+  }
+}

--- a/src/app/views/patients/shared/interfaces/PatientLink.interface.ts
+++ b/src/app/views/patients/shared/interfaces/PatientLink.interface.ts
@@ -1,0 +1,8 @@
+export interface PatientLink {
+  id: number;
+  patientId: number;
+  patientType: 'user' | 'dependent';
+  firstName: string;
+  lastName: string;
+  createdAt: string;
+}

--- a/src/app/views/patients/shared/services/patients.service.ts
+++ b/src/app/views/patients/shared/services/patients.service.ts
@@ -1,0 +1,46 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { environment } from 'src/environments/environment';
+import { PatientLink } from '../interfaces/PatientLink.interface';
+import { MedicalDocument } from 'src/app/views/documents/shared/interfaces/Document.interface';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class PatientsService {
+  constructor(private http: HttpClient) {}
+
+  getPatients(): Promise<PatientLink[]> {
+    return this.http
+      .get<PatientLink[]>(`${environment.apiUrl}/professionals/patients`)
+      .toPromise();
+  }
+
+  linkPatient(patientId: number, patientType: string): Promise<any> {
+    return this.http
+      .post(`${environment.apiUrl}/professionals/patients`, {
+        patientId,
+        patientType,
+      })
+      .toPromise();
+  }
+
+  unlinkPatient(patientId: number, patientType: string): Promise<any> {
+    return this.http
+      .delete(
+        `${environment.apiUrl}/professionals/patients/${patientId}?patientType=${patientType}`
+      )
+      .toPromise();
+  }
+
+  getPatientDocuments(
+    patientId: number,
+    patientType: string
+  ): Promise<MedicalDocument[]> {
+    return this.http
+      .get<MedicalDocument[]>(
+        `${environment.apiUrl}/professionals/patients/${patientId}/documents?patientType=${patientType}`
+      )
+      .toPromise();
+  }
+}

--- a/src/app/views/profile/profile.page.ts
+++ b/src/app/views/profile/profile.page.ts
@@ -36,19 +36,33 @@ import { PROFILE_OPTIONS } from './constants/profile-options';
   styleUrls: ['./profile.page.scss'],
 })
 export class ProfilePage implements OnInit {
-  options = PROFILE_OPTIONS;
+  options = [];
   constructor(private auth: AuthenticationService, private navController: NavController) {}
 
   ngOnInit() {}
   ionViewWillEnter() {
-    this.setUserEmail();
+    this.buildOptions();
   }
   logout() {
     this.auth.signOut();
     return this.navController.navigateRoot(['welcome']);
   }
-  setUserEmail() {
-    this.options[0].title = `${this.auth.user().firstName}`;
+  buildOptions() {
+    const user = this.auth.user();
+    this.options = JSON.parse(JSON.stringify(PROFILE_OPTIONS));
+    this.options[0].title = user.firstName;
+
+    if (user.role === 'professional') {
+      // Replace "Mis Profesionales" (index 1) with "Mis Pacientes"
+      this.options[1] = {
+        icon: 'people-outline',
+        title: 'Mis Pacientes',
+        action: {
+          type: 'navigate',
+          payload: '/patients',
+        },
+      };
+    }
   }
 
   doAction(event) {


### PR DESCRIPTION
## Summary
- Adds Patients section: list, add-patient, and patient-documents views
- New `PatientsService` + `PatientLink` interface to consume backend linkage endpoints
- Wires patients routes and updates profile page entry point

## Test plan
- [ ] Navigate to Patients from profile
- [ ] Add a new patient and verify it links to the professional
- [ ] Open a patient and view their documents
- [ ] Verify existing profile flows are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)