### PR TITLE
feat(meds-events): polish create/edit/cancel flows and fix group doc tab

### DIFF
--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -5,6 +5,10 @@ const config: CapacitorConfig = {
   appName: 'Sigsa',
   webDir: 'www',
   bundledWebRuntime: false,
+  server: {
+    url: 'http://10.0.2.2:8100',
+    cleartext: true,
+  },
   plugins: {
     LocalNotifications: {
       smallIcon: 'sigsa_logo',

--- a/src/app/components/reminders/reminders.component.ts
+++ b/src/app/components/reminders/reminders.component.ts
@@ -5,7 +5,7 @@ import { REMINDERS_TYPE } from 'src/app/views/home/shared/constants/remindersTyp
   selector: 'app-reminders',
   template: `
     <div class="rem">
-      <ion-segment class="rem__segment" (ionChange)="changeReminders($event)" [value]="remindersTypes.appointments">
+      <ion-segment class="rem__segment" (ionChange)="changeReminders($event)" [value]="activeTab">
         <ion-segment-button class="rem__segment__button" [value]="remindersTypes.medications">
           <ion-label>Medicamentos</ion-label>
         </ion-segment-button>
@@ -30,6 +30,13 @@ import { REMINDERS_TYPE } from 'src/app/views/home/shared/constants/remindersTyp
         [appointment]="appointment"
         (click)="onItemClick(appointment)"
       ></app-appointments-item-list>
+    </cdk-virtual-scroll-viewport>
+    <cdk-virtual-scroll-viewport *ngIf="activeTab === remindersTypes.documents" itemSize="3">
+      <app-document-item-list
+        *cdkVirtualFor="let document of this.reminders"
+        [document]="document"
+        (click)="onItemClick(document)"
+      ></app-document-item-list>
     </cdk-virtual-scroll-viewport>
   `,
   styleUrls: ['./reminders.component.scss'],

--- a/src/app/components/shared-components.module.ts
+++ b/src/app/components/shared-components.module.ts
@@ -18,6 +18,7 @@ import { ScrollingModule } from '@angular/cdk/scrolling';
 import { AppointmentsItemListComponent } from './appointments-item-list/appointments-item-list.component';
 import { YesNoModalComponent } from './yes-no-modal/yes-no-modal.component';
 import { MedsEventsItemListComponent } from './meds-event-item-list/meds-event-item-list.component';
+import { SharedDocumentsModule } from '../views/documents/shared/shared-documents.module';
 
 @NgModule({
   declarations: [
@@ -36,7 +37,7 @@ import { MedsEventsItemListComponent } from './meds-event-item-list/meds-event-i
     YesNoModalComponent,
     MedsEventsItemListComponent
   ],
-  imports: [SwiperModule, CommonModule, IonicModule, FormsModule, ReactiveFormsModule, ScrollingModule],
+  imports: [SwiperModule, CommonModule, IonicModule, FormsModule, ReactiveFormsModule, ScrollingModule, SharedDocumentsModule],
   exports: [
     HeaderComponent,
     SendVerificationEmailModalComponent,

--- a/src/app/views/documents/create-document/create-document.page.ts
+++ b/src/app/views/documents/create-document/create-document.page.ts
@@ -15,7 +15,7 @@ import { CreateDocumentDTO } from '../shared/interfaces/Document.interface';
     <ion-header class="ui-background__light">
       <ion-toolbar class="ui-toolbar__primary">
         <ion-buttons slot="start">
-          <ion-back-button [defaultHref]="dependentId ? '/groups/' + groupId : '/tabs/clipboard'"></ion-back-button>
+          <ion-back-button [defaultHref]="dependentId ? '/groups/home/' + groupId : '/tabs/clipboard'"></ion-back-button>
         </ion-buttons>
         <ion-title class="ui-header__title-center">
           {{ isEditMode ? 'Editar' : 'Nuevo' }} Documento{{ dependentName ? ' de ' + dependentName : '' }}
@@ -324,7 +324,7 @@ export class CreateDocumentPage implements OnInit {
         // Crear documento para dependiente
         await this.documentsService.createDocumentForDependent(this.dependentId, payload);
         this.toastService.showSuccess(`Documento creado correctamente para ${this.dependentName}`);
-        this.navController.navigateBack(['/groups/' + this.groupId]);
+        this.navController.navigateRoot(['/groups/home/' + this.groupId]);
       } else {
         // Crear documento para usuario
         await this.documentsService.createDocument(payload);
@@ -349,7 +349,7 @@ export class CreateDocumentPage implements OnInit {
       
       if (this.dependentId) {
         // Navegar de vuelta al grupo si estamos editando un documento de dependiente
-        this.navController.navigateBack(['/groups/' + this.groupId]);
+        this.navController.navigateRoot(['/groups/home/' + this.groupId]);
       } else {
         // Navegar a la lista de documentos si estamos editando un documento propio
         this.navController.navigateRoot(['/tabs/clipboard']);

--- a/src/app/views/groups/group-home/group-home.page.ts
+++ b/src/app/views/groups/group-home/group-home.page.ts
@@ -14,6 +14,7 @@ import { AuthenticationService } from 'src/app/services/authentication/authentic
 import { EventsService } from '../../home/shared/services/events/events.service';
 import { AppointmentsService } from '../../appointments/shared/services/appointments/appointments.service';
 import { MedsEventsService } from '../../meds/shared/services/meds-events/meds-events.service';
+import { MedsEventDataService } from '../../meds/shared/services/meds-events-data/meds-events-data.service';
 import { DocumentsService } from '../../documents/shared/services/documents.service';
 
 @Component({
@@ -107,6 +108,7 @@ export class GroupHomePage implements OnInit {
     private eventsService: EventsService,
     private appointmentsService: AppointmentsService,
     private medsEventsService: MedsEventsService,
+    private medsEventDataService: MedsEventDataService,
     private documentsService: DocumentsService,
     private actionSheetService: ActionSheetService,
     private modalController: ModalController
@@ -268,7 +270,10 @@ export class GroupHomePage implements OnInit {
     await modal.present();
     const { data } = await modal.onWillDismiss();
     if (data) {
-      // TODO: Integrar con appointmentsService.cancelAppointment(id) si es necesario en contexto de grupo
+      await this.appointmentsService
+        .cancelAppointment(id)
+        .then(() => this.changeReminders(this.currentReminderType))
+        .catch(err => console.error('Error cancelando turno:', err));
     }
   }
 
@@ -320,11 +325,17 @@ export class GroupHomePage implements OnInit {
       componentProps: { text: '¿Desea cancelar el recordatorio de medicamento?' },
     });
     await modal.present();
-    await modal.onWillDismiss();
-    // TODO: Integrar con medsEventsService.cancelMedEvent(id) si existe en contexto de grupo
+    const { data } = await modal.onWillDismiss();
+    if (data) {
+      await this.medsEventsService
+        .cancelMedEvent(id)
+        .then(() => this.changeReminders(this.currentReminderType))
+        .catch(err => console.error('Error cancelando medicamento:', err));
+    }
   }
 
   private editMedEvent(id: number) {
+    this.medsEventDataService.clean();
     return this.navController.navigateForward([`/meds/edit/${id}/pick-med`], {
       queryParams: {
         dependentId: this.group?.dependent?.id,

--- a/src/app/views/meds/create-med-event/create-med-event.component.ts
+++ b/src/app/views/meds/create-med-event/create-med-event.component.ts
@@ -77,7 +77,7 @@ export class CreateMedEventComponent implements OnInit {
     date: null,
   });
   showCalendar = false;
-  minDate = formatISO(new Date(Date.now() - 24 * 60 * 60 * 1000));
+  minDate = formatISO(new Date());
   med: any;
   medEventDate;
   medEventId: number;
@@ -184,9 +184,8 @@ export class CreateMedEventComponent implements OnInit {
     this.isSubmitting = true;
     try {
       const payload: any = { date: isoDate };
-      // Permitir cambio de medicamento si se llegó desde pick-med y se cambió
-      const medId = this.medsEventDataService.data?.medId;
-      if (medId && medId !== this.med?.id) {
+      const medId = this.medsEventDataService.data?.medId || this.med?.id;
+      if (medId) {
         payload.medId = medId;
       }
       await this.medsEventService.editMedEvent(this.medEventId, payload);
@@ -215,7 +214,7 @@ export class CreateMedEventComponent implements OnInit {
       this.toastService.showError?.('Fecha inválida');
       return;
     }
-    if (dateObj.getTime() < Date.now() - 24 * 60 * 60 * 1000) { // testing: permite hasta ayer
+    if (dateObj.getTime() < Date.now() - 60000) {
       this.toastService.showError?.('La fecha debe ser futura');
       return;
     }
@@ -243,19 +242,20 @@ export class CreateMedEventComponent implements OnInit {
     } else if (depId) {
       return this.navController.navigateBack('/groups');
     }
-    return this.navController.navigateForward('/tabs/meds');
+    return this.navController.navigateRoot('/tabs/meds');
   }
 
   successEdition() {
     this.toastService.showSuccess('Recordatorio de medicamento editado correctamente.');
     const depId = this.dependentId || this.medsEventDataService.data?.dependentId;
     const grpId = this.groupId || this.medsEventDataService.data?.groupId;
+    this.medsEventDataService.clean();
     if (depId && grpId) {
       return this.navController.navigateRoot(`/groups/home/${grpId}`);
     } else if (depId) {
       return this.navController.navigateBack('/groups');
     }
-    return this.navController.navigateForward('/tabs/meds');
+    return this.navController.navigateRoot('/tabs/meds');
   }
 
   dispatch(notification, id) {
@@ -277,13 +277,18 @@ export class CreateMedEventComponent implements OnInit {
         this.toastService.showError?.('Recordatorio no encontrado');
         return;
       }
-      this.med = medEvent.med;
+      // Si el usuario cambió el med en pick-med, respetar esa elección.
+      // Si el data service está vacío (primera entrada al wizard de edición), usar el de la API.
+      const savedMed = this.medsEventDataService.data?.med;
+      this.med = savedMed ?? medEvent.med;
       if (!this.form.get('med')) {
         this.form.addControl('med', new FormControl(this.med));
       } else {
         this.form.get('med').setValue(this.med);
       }
-      this.medsEventDataService.update({ med: this.med, medId: this.med?.id });
+      if (!savedMed) {
+        this.medsEventDataService.update({ med: this.med, medId: this.med?.id });
+      }
       this.medEventDate = medEvent.date;
       this.form.get('date').setValue(this.dateFormatterService.getSpanishFormattedDate(medEvent.date));
     } catch (err) {

--- a/src/app/views/meds/meds.page.ts
+++ b/src/app/views/meds/meds.page.ts
@@ -1,11 +1,15 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnDestroy, OnInit } from '@angular/core';
 import { FormBuilder } from '@angular/forms';
+import { NavigationEnd, Router } from '@angular/router';
 import { ModalController, NavController } from '@ionic/angular';
 import { isBefore, parseISO } from 'date-fns';
+import { Subscription } from 'rxjs';
+import { filter } from 'rxjs/operators';
 import { YesNoModalComponent } from 'src/app/components/yes-no-modal/yes-no-modal.component';
 import { ActionSheetService } from 'src/app/services/action-sheet/action-sheet.service';
 import { ToastService } from 'src/app/services/toast/toast.service';
 import { MedsEventsService } from './shared/services/meds-events/meds-events.service';
+import { MedsEventDataService } from './shared/services/meds-events-data/meds-events-data.service';
 
 @Component({
   selector: 'app-meds',
@@ -41,22 +45,38 @@ import { MedsEventsService } from './shared/services/meds-events/meds-events.ser
   `,
   styleUrls: ['./meds.page.scss'],
 })
-export class MedsPage implements OnInit {
+export class MedsPage implements OnInit, OnDestroy {
   medsEvents: any[] = [];
   filteredMedsEvents: any[] = [];
   searchForm = this.fb.group({
     search: '',
   });
+  private routerSub: Subscription | undefined;
+
   constructor(
     private fb: FormBuilder,
     private navController: NavController,
+    private router: Router,
     private medsEventsService: MedsEventsService,
+    private medsEventDataService: MedsEventDataService,
     private actionSheetService: ActionSheetService,
     private modalController: ModalController,
     private toastService: ToastService
   ) {}
 
-  ngOnInit() {}
+  ngOnInit() {
+    this.routerSub = this.router.events
+      .pipe(filter((e): e is NavigationEnd => e instanceof NavigationEnd))
+      .subscribe(e => {
+        if (e.urlAfterRedirects === '/tabs/meds' || e.url === '/tabs/meds') {
+          this.setMedsEvents();
+        }
+      });
+  }
+
+  ngOnDestroy() {
+    this.routerSub?.unsubscribe();
+  }
 
   async ionViewWillEnter() {
     this.setMedsEvents();
@@ -104,11 +124,11 @@ export class MedsPage implements OnInit {
     await modal.present();
     const { data } = await modal.onWillDismiss();
     if (data) {
-      // await this.appointmentsService
-      //   .cancelAppointment(id)
-      //   .then(() => this.toastService.showSuccess('Turno cancelado correctamente.'))
-      //   .then(() => this.setAppointments())
-      //   .catch(() => {});
+      await this.medsEventsService
+        .cancelMedEvent(id)
+        .then(() => this.toastService.showSuccess('Recordatorio cancelado correctamente.'))
+        .then(() => this.setMedsEvents())
+        .catch(() => this.toastService.showError('No se pudo cancelar el recordatorio.'));
     }
   }
 
@@ -122,6 +142,7 @@ export class MedsPage implements OnInit {
   }
 
   editMedEvent(id) {
+    this.medsEventDataService.clean();
     return this.navController.navigateForward([`/meds/edit/${id}/pick-med`]);
   }
 

--- a/src/app/views/meds/pick-med/pick-med.component.ts
+++ b/src/app/views/meds/pick-med/pick-med.component.ts
@@ -77,7 +77,6 @@ export class PickMedComponent implements OnInit, OnDestroy {
   ngOnInit() {}
 
   ionViewWillEnter() {
-    // Capturar parámetros del dependiente si existen
     this.route.queryParams.subscribe(params => {
       const rawDependentId = params['dependentId'];
       this.dependentId = rawDependentId !== undefined && rawDependentId !== null && rawDependentId !== ''
@@ -94,7 +93,6 @@ export class PickMedComponent implements OnInit, OnDestroy {
       }
     });
     this.getMeds();
-    this.setMedIfBack();
     this.setMode();
   }
 
@@ -102,23 +100,34 @@ export class PickMedComponent implements OnInit, OnDestroy {
     this.medEventId = Number(this.route.snapshot.paramMap.get('id'));
     if (this.medEventId) {
       this.isEditMode = true;
-      // this.setAppointmentInfo();
+      const savedMed = this.medEventDataService.data?.med;
+      if (savedMed) {
+        // Usuario volvió atrás desde el paso 2 con un med ya elegido
+        this.med = savedMed;
+      } else {
+        // Primera entrada al wizard de edición: cargar el med actual desde la API
+        this.loadCurrentMed();
+      }
+    } else {
+      // Modo creación: restaurar selección si el usuario volvió atrás
+      if (this.medEventDataService.data?.med) {
+        this.med = this.medEventDataService.data.med;
+      }
     }
   }
 
-  // async setAppointmentInfo() {
-  // const appointment = await this.appointmentsService.getAppointment(this.appointmentId);
-  // this.setDoctor(appointment.professional);
-  // this.appointmentDataService.update(appointment);
-  // }
+  private async loadCurrentMed() {
+    try {
+      const medEvent = await this.medsEventsService.getMedEvent(this.medEventId);
+      if (medEvent?.med) {
+        this.med = medEvent.med;
+        this.medEventDataService.update({ med: this.med, medId: this.med.id });
+      }
+    } catch {}
+  }
 
   setMed(value) {
     this.med = value;
-  }
-  setMedIfBack() {
-    if (this.medEventDataService.data?.med) {
-      this.med = this.medEventDataService.data?.med;
-    }
   }
 
   async handleChange(event) {
@@ -132,10 +141,9 @@ export class PickMedComponent implements OnInit, OnDestroy {
   }
 
   nextStep() {
-    // Guardar solo medId (normalizado) y metadatos del dependiente si existen
-    this.medEventDataService.update({ 
+    this.medEventDataService.update({
       medId: this.med?.id,
-      med: this.med, // mantener referencia completa si pasos siguientes la usan para mostrar info
+      med: this.med,
       dependentId: this.dependentId,
       dependentName: this.dependentName,
       groupId: this.groupId,

--- a/src/app/views/meds/shared/services/meds-events/meds-events.service.ts
+++ b/src/app/views/meds/shared/services/meds-events/meds-events.service.ts
@@ -8,22 +8,6 @@ import { environment } from 'src/environments/environment';
 export class MedsEventsService {
   constructor(private http: HttpClient) {}
 
-  editAppointment(id, data) {
-    return this.http.put(`${environment.apiUrl}/appointments/${id}`, data).toPromise();
-  }
-
-  cancelAppointment(id) {
-    return this.http.delete(`${environment.apiUrl}/appointments/cancel/${id}`).toPromise();
-  }
-
-  confirmAppointment(id) {
-    return this.http.put(`${environment.apiUrl}/appointments/confirm/${id}`, {}).toPromise();
-  }
-
-  getAppointment(id: number) {
-    return this.http.get<any>(`${environment.apiUrl}/appointments/${id}`).toPromise();
-  }
-  
   getMedsEventsByUser() {
     return this.http.get<any[]>(`${environment.apiUrl}/meds-event`).toPromise();
   }
@@ -32,8 +16,11 @@ export class MedsEventsService {
     return this.http.get<any[]>(`${environment.apiUrl}/meds-event/dependent/${dependentId}`).toPromise();
   }
 
+  getMedEvent(id: number) {
+    return this.http.get<any>(`${environment.apiUrl}/meds-event/${id}`).toPromise();
+  }
+
   createMedEvent(data) {
-    // Normalizar payload: aceptar data.med (objeto) o data.medId (número)
     let payload = data;
     if (data && !data.medId && data.med && typeof data.med === 'object' && 'id' in data.med) {
       payload = { medId: data.med.id, date: data.date };
@@ -49,20 +36,23 @@ export class MedsEventsService {
     return this.http.post(`${environment.apiUrl}/meds-event/dependent/${dependentId}`, payload).toPromise();
   }
 
-  getMeds(): Promise<any[]> {
-    return this.http.get<any[]>(`${environment.apiUrl}/meds/all`).toPromise();
-  }
-  // Nota: El backend actual no expone GET /meds-event/:id; se obtiene por listado y filtrado.
-  // Si se habilita PUT /meds-event/:id para edición, se puede reintroducir editMedEvent aquí.
-  getMedEvent(id: number) {
-    return this.http.get<any>(`${environment.apiUrl}/meds-event/${id}`).toPromise();
-  }
-
   editMedEvent(id: number, data: { medId?: number; date?: string }) {
     let payload: any = data;
     if (data && !data.medId && (data as any).med && typeof (data as any).med === 'object' && 'id' in (data as any).med) {
       payload = { medId: (data as any).med.id, date: (data as any).date };
     }
-    return this.http.put<any>(`${environment.apiUrl}/meds-event/${id}`, payload).toPromise();
+    return this.http.patch<any>(`${environment.apiUrl}/meds-event/${id}`, payload).toPromise();
+  }
+
+  cancelMedEvent(id: number) {
+    return this.http.patch<any>(`${environment.apiUrl}/meds-event/${id}/cancel`, {}).toPromise();
+  }
+
+  confirmMedEvent(id: number) {
+    return this.http.patch<any>(`${environment.apiUrl}/meds-event/${id}/confirm`, {}).toPromise();
+  }
+
+  getMeds(): Promise<any[]> {
+    return this.http.get<any[]>(`${environment.apiUrl}/meds/all`).toPromise();
   }
 }


### PR DESCRIPTION
Meds events:
- Add GET/PATCH service methods (getMedEvent, editMedEvent via PATCH, cancelMedEvent, confirmMedEvent)
- Remove stale appointment methods that pointed to wrong URLs
- Fix edit wizard: load current med from API on first entry, respect user selection on back navigation
- Fix editMedEvent payload to always include medId so medication change persists
- Fix minDate to today (was yesterday) and future-date validation tolerance to 1 min
- Connect cancel action in meds list with toast and refresh
- Navigate with navigateRoot after create/edit so ionViewWillEnter refreshes the list
- Subscribe to NavigationEnd in meds.page to refresh list when returning via tab switch
- Clean MedsEventDataService before entering edit wizard to avoid stale state

Group home:
- Implement cancel for appointments and med events (was TODO)
- Clean MedsEventDataService before edit navigation
- Fix ion-segment [value] hardcoded to appointments → bind to activeTab so indicator matches content

Documents:
- Fix create/edit navigation for dependent context: /groups/:id → /groups/home/:id (non-existent route)
- Use navigateRoot instead of navigateBack to trigger ionViewWillEnter refresh on group home
- Add documents viewport to RemindersComponent (tab button existed but content was missing)
- Import SharedDocumentsModule into SharedComponentsModule so app-document-item-list resolves

Capacitor:
- Add live reload server config for Android emulator (10.0.2.2:8100)